### PR TITLE
Add `nullable` and `nonnull` modifiers for a better interop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: objective-c
-before_script:
-    - brew update
-    - brew install xctool && brew cleanup xctool
 script:
     - cd NitroKeychain
     - xcodebuild -project NitroKeychain.xcodeproj -scheme NitroKeychain -destination 'platform=iOS Simulator,name=iPhone Retina (4-inch)' test

--- a/NitroKeychain/NitroKeychain/TNTKeychain.h
+++ b/NitroKeychain/NitroKeychain/TNTKeychain.h
@@ -29,7 +29,7 @@
  *  @see +delete:
  *  @see +delete:accessGroup:
  */
-+( BOOL )save:( NSString * )keychainItemId data:( id )data;
++( BOOL )save:( nonnull NSString * )keychainItemId data:( nullable id )data;
 
 /**
  *  Stores data into the keychain associating it to keychainItemId. If there is
@@ -54,7 +54,7 @@
  *  @see +delete:
  *  @see +delete:accessGroup:
  */
-+( BOOL )save:( NSString * )keychainItemId data:( id )data accessGroup:( NSString * )accessGroup;
++( BOOL )save:( nonnull NSString * )keychainItemId data:( nullable id )data accessGroup:( nullable NSString * )accessGroup;
 
 /**
  *  Loads the data associated with a keychain item.
@@ -70,7 +70,7 @@
  *  @see +delete:
  *  @see +delete:accessGroup:
  */
-+( id )load:( NSString * )keychainItemId;
++( nullable id )load:( nonnull NSString * )keychainItemId;
 
 /**
  *  Loads the data associated with a keychain item.
@@ -88,7 +88,7 @@
  *  @see +delete:
  *  @see +delete:accessGroup:
  */
-+( id )load:( NSString * )keychainItemId accessGroup:( NSString * )accessGroup;
++( nullable id )load:( nonnull NSString * )keychainItemId accessGroup:( nullable NSString * )accessGroup;
 
 /**
  *  Deletes the specified keychain item. This method does nothing if keychainItemId
@@ -102,7 +102,7 @@
  *  @see +load:accessGroup:
  *  @see +delete:accessGroup:
  */
-+( void )delete:( NSString * )keychainItemId;
++( void )delete:( nonnull NSString * )keychainItemId;
 
 /**
  *  Deletes the specified keychain item. This method does nothing if keychainItemId
@@ -118,6 +118,6 @@
  *  @see +load:accessGroup:
  *  @see +delete:
  */
-+( void )delete:( NSString * )keychainItemId accessGroup:( NSString * )accessGroup;
++( void )delete:( nonnull NSString * )keychainItemId accessGroup:( nullable NSString * )accessGroup;
 
 @end

--- a/NitroKeychain/NitroKeychain/TNTKeychain.m
+++ b/NitroKeychain/NitroKeychain/TNTKeychain.m
@@ -93,12 +93,12 @@ static NSOperationQueue *serializerQueue;
 
 #pragma mark - Save
 
-+( BOOL )save:( NSString * )keychainItemId data:( id )data
++( BOOL )save:( nonnull NSString * )keychainItemId data:( nullable id )data
 {
     return [self save: keychainItemId data: data accessGroup: nil];
 }
 
-+( BOOL )save:( NSString * )keychainItemId data:( id )data accessGroup:( NSString * )accessGroup
++( BOOL )save:( nonnull NSString * )keychainItemId data:( nullable id )data accessGroup:( nullable NSString * )accessGroup
 {
     if( keychainItemId.length == 0 || data == nil )
         return NO;
@@ -136,12 +136,12 @@ static NSOperationQueue *serializerQueue;
 
 #pragma mark - Load
 
-+( id )load:( NSString * )keychainItemId
++( nullable id )load:( nonnull NSString * )keychainItemId
 {
     return [self load: keychainItemId accessGroup: nil];
 }
 
-+( id )load:( NSString * )keychainItemId accessGroup:( NSString * )accessGroup
++( nullable id )load:( nonnull NSString * )keychainItemId accessGroup:( nullable NSString * )accessGroup
 {
     if( keychainItemId.length == 0 )
         return nil;
@@ -176,12 +176,12 @@ static NSOperationQueue *serializerQueue;
 
 #pragma mark - Delete
 
-+( void )delete:( NSString * )keychainItemId
++( void )delete:( nonnull NSString * )keychainItemId
 {
     [self delete: keychainItemId accessGroup: nil];
 }
 
-+( void )delete:( NSString * )keychainItemId accessGroup:( NSString * )accessGroup
++( void )delete:( nonnull NSString * )keychainItemId accessGroup:( nullable NSString * )accessGroup
 {
     if( keychainItemId.length == 0 )
         return;

--- a/NitroKeychain/NitroKeychainTests/NitroKeychainTests.m
+++ b/NitroKeychain/NitroKeychainTests/NitroKeychainTests.m
@@ -31,6 +31,9 @@ static NSString * const kTestServiceName = @"tnt.keychain.test";
 
 #pragma mark - NitroKeychainTests Implementation
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
 @implementation NitroKeychainTests
 
 #pragma mark - Test Lifecycle
@@ -201,3 +204,5 @@ static NSString * const kTestServiceName = @"tnt.keychain.test";
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ There are 3 operations: `save`, `load` and `delete`, as you can see below:
 Saving
 ------
 
+#### Objective-C
+
 ```objc
 [TNTKeychain save: @"com.myapp.service.id" 
              data: @"my-ultra-secret-token"];
@@ -23,12 +25,26 @@ Saving
 
 ```
 
+#### Swift
+
+```swift
+TNTKeychain.save("com.myapp.service.id", data: "my-ultra-secret-token")
+             
+// Or, if you want to make this item available across apps, specify 
+// an access group:
+TNTKeychain.save("com.myapp.service.id", 
+                  data: "my-ultra-secret-token", 
+                  accessGroup: "super-company")
+```
+
 - All keychain items are stored using the kSecClassGenericPassword Keychain Item class.
 - `data` can be any value compatible with `NSKeyedArchiver`/`NSKeyedUnarchiver`.
 - If there is already some data associated with a keychain item ID, it will be updated.
 
 Loading
 -------
+
+#### Objective-C
 
 ```objc
 NSString *token = [TNTKeychain load: @"com.myapp.service.id"];
@@ -37,14 +53,29 @@ NSLog( @"%@", token );
 
 - `load` will return `nil` if no keychain item is found with such id.
 
+#### Swift
+
+```swift
+let token = TNTKeychain.load("com.myapp.service.id")
+print(token)
+```
+
 Deleting
 --------
+
+#### Objective-C
 
 ```objc
 [TNTKeychain delete: @"com.myapp.service.id"];
 ```
 
 - `delete` does nothing if no keychain item is found with such id.
+
+#### Swift
+
+```swift
+TNTKeychain.delete("com.myapp.service.id")
+```
 
 Simple as that :+1:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ NitroKeychain
 =============
 [![Version](http://cocoapod-badges.herokuapp.com/v/NitroKeychain/badge.png)](http://cocoadocs.org/docsets/NitroKeychain)
 [![Platform](http://cocoapod-badges.herokuapp.com/p/NitroKeychain/badge.png)](http://cocoadocs.org/docsets/NitroKeychain)
-<!-- [![TravisCI](https://travis-ci.org/danielalves/NitroKeychain.svg?branch=master)](https://travis-ci.org/danielalves/NitroKeychain) -->
+[![TravisCI](https://travis-ci.org/danielalves/NitroKeychain.svg?branch=master)](https://travis-ci.org/danielalves/NitroKeychain)
 
 **NitroKeychain** is a thin, yet powerful, abstraction layer on top of iOS keychain that provides commonly needed features. **NitroKeychain** is also thread safe.
 


### PR DESCRIPTION
This way we avoid implicit unwrapped optionals being returned from `load` (like `Any!`) and we guarantee that the `key` parameter has always a valid value in Swift (not being an optional).

Current method signatures in Swift:
```swift
open class func save(_ keychainItemId: String!, data: Any!) -> Bool
open class func save(_ keychainItemId: String!, data: Any!, accessGroup: String!) -> Bool
open class func load(_ keychainItemId: String!) -> Any!
open class func load(_ keychainItemId: String!, accessGroup: String!) -> Any!
open class func delete(_ keychainItemId: String!)
open class func delete(_ keychainItemId: String!, accessGroup: String!)
```

New method signatures in Swift:
```swift
open class func save(_ keychainItemId: String, data: Any?) -> Bool
open class func save(_ keychainItemId: String, data: Any?, accessGroup: String?) -> Bool
open class func load(_ keychainItemId: String) -> Any?
open class func load(_ keychainItemId: String, accessGroup: String?) -> Any?
open class func delete(_ keychainItemId: String)
open class func delete(_ keychainItemId: String, accessGroup: String?)
```

more: https://developer.apple.com/swift/blog/?id=25

**UPDATE:**
Build seems to be fixed 🎉 so I'm adding the badge back to `README.md`.

fixes #3 